### PR TITLE
[BACKLOG-5202] Inline modeling should not be available in agilebi

### DIFF
--- a/src/org/pentaho/agilebi/spoon/visualizations/analyzer/AnalyzerVisualization.java
+++ b/src/org/pentaho/agilebi/spoon/visualizations/analyzer/AnalyzerVisualization.java
@@ -192,6 +192,10 @@ public class AnalyzerVisualization extends AbstractVisualization {
     // the rnd param is to make sure that the browser does not display a cached version of the requested report
     long avoidBrowserCache = Calendar.getInstance().getTimeInMillis();
     str += "&rnd=" + avoidBrowserCache;
+
+    // restrict inline modeling functionality using query string parameter
+    str += "&hasInlineModelingPermission=false";
+
     return str;
 	}
 	


### PR DESCRIPTION
Introduced a new query string parameter, hasInlineModelingPermission. When set to false, inline modeling functionality will not be present. Modified agile-bi to always use this parameter when loading Analyzer to prevent inline modeling functionality from being available in Spoon.