### PR TITLE
[BACKLOG-6459] Remove empty ESAPI.properties.  This file was slowing …

### DIFF
--- a/res/ESAPI.properties
+++ b/res/ESAPI.properties
@@ -1,2 +1,0 @@
-# ESAPI config file; must be present but we take all of the defaults
-# http://www.owasp.org/index.php/XSS_(Cross_Site_Scripting)_Prevention_Cheat_Sheet


### PR DESCRIPTION
…down Repository Import.  A populated ESAPI.properties comes from the kettle-core.jar