### PR TITLE
[BACKLOG-8388] - Upgrade Jersey to 1.19.1 across the suite for Java 8  compatibility

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -213,6 +213,7 @@
 
             <!-- Move Jersey to pdi-ee\lib-->
             <include name="jersey-multipart*.jar"/>
+            <include name="mimepull*.jar"/>
             <include name="jersey-apache-client*.jar"/>
             <include name="jersey-client*.jar"/>
             <include name="jersey-servlet*.jar"/>

--- a/ivy.xml
+++ b/ivy.xml
@@ -149,13 +149,25 @@
     <dependency org="org.apache.axis2" name="axis2-java2wsdl" rev="1.5" transitive="false"/>
 
 	<!-- jersey -->
-    <dependency org="com.sun.jersey.contribs" name="jersey-multipart" rev="1.16"/>
-    <dependency org="com.sun.jersey.contribs" name="jersey-apache-client" rev="1.14" transitive="false"/>
-    <dependency org="com.sun.jersey" name="jersey-bundle" rev="1.16" transitive="false"/>
+    <dependency org="com.sun.jersey.contribs" name="jersey-multipart" rev="1.19.1" transitive="false"/>
+    <dependency org="org.jvnet.mimepull"      name="mimepull"         rev="1.9.3" transitive="false"/>
+    <dependency org="com.sun.jersey.contribs" name="jersey-apache-client" rev="1.19.1" transitive="false"/>
+    <dependency org="com.sun.jersey" name="jersey-bundle" rev="1.19.1" transitive="false"/>
     <!-- jersey -->
-    <dependency org="com.sun.jersey" name="jersey-core" rev="1.16" transitive="false"/>
-    <dependency org="com.sun.jersey" name="jersey-json" rev="1.16" transitive="true"/>
-    <dependency org="com.sun.jersey" name="jersey-client" rev="1.16" transitive="true"/>
+    <dependency org="com.sun.jersey" name="jersey-core" rev="1.19.1" transitive="false"/>
+    <dependency org="com.sun.jersey" name="jersey-json" rev="1.19.1" transitive="false"/>
+    <!--here jersey-json transitive dependencies started-->
+      <dependency org="org.codehaus.jackson" name="jackson-xc" rev="1.9.2" transitive="false"/>
+      <dependency org="org.codehaus.jackson" name="jackson-mapper-asl" rev="1.9.2" transitive="false"/>
+      <dependency org="org.codehaus.jackson" name="jackson-core-asl" rev="1.9.2" transitive="false"/>
+      <dependency org="org.codehaus.jackson" name="jackson-jaxrs" rev="1.9.2" transitive="false"/>
+      <dependency org="org.codehaus.jettison" name="jettison" rev="1.1" transitive="false"/>
+      <dependency org="com.sun.xml.bind" name="jaxb-impl" rev="2.2.3-1" transitive="false"/>
+      <dependency org="javax.xml.bind" name="jaxb-api" rev="2.2.2" transitive="false"/>
+      <dependency org="javax.xml.stream" name="stax-api" rev="1.0-2" transitive="false"/>
+      <dependency org="javax.activation" name="activation" rev="1.1" transitive="false"/>
+      <!--here jersey-json transitive dependencies finished-->
+    <dependency org="com.sun.jersey" name="jersey-client" rev="1.19.1" transitive="true"/>
     <dependency org="javax.ws.rs" name="jsr311-api" rev="1.1.1" transitive="false"/>
 
     <dependency org="pentaho" name="pentaho-platform-core-test" rev="${dependency.bi-platform.revision}" changing="true" conf="test->default" transitive="false" />


### PR DESCRIPTION
The fix is needed due to using java 1.8, and incompatibility of asm old version (is used by jersey) reading new java 1.8 features 
The following scope of repositories is upgraded(except webdetails): The list is sorted in the order of build team runs

https://github.com/pentaho/pentaho-reporting
https://github.com/pentaho/mondrian
https://github.com/pentaho/pentaho-kettle
https://github.com/pentaho/pentaho-mondrianschemaworkbench-plugins
https://github.com/pentaho/pentaho-platform
https://github.com/webdetails/cpf
https://github.com/pentaho/pentaho-metaverse
https://github.com/pentaho/pdi-platform-utils-plugin
https://github.com/pentaho/pentaho-data-profiling
https://github.com/pentaho/data-access
https://github.com/pentaho/big-data-plugin
https://github.com/pentaho/pentaho-data-refinery
https://github.com/webdetails/cde
https://github.com/webdetails/cpk
https://github.com/webdetails/cda
https://github.com/pentaho/pentaho-platform-plugin-mobile
https://github.com/pentaho/pentaho-karaf-assembly
https://github.com/pentaho/pentaho-karaf-ee-assembly
https://github.com/pentaho/pdi-sdk-plugins
https://github.com/pentaho/pdi-ee-plugin
https://github.com/pentaho/pdi-agile-bi-plugin
https://github.com/pentaho/pentaho-aggdesigner
https://github.com/pentaho/pentaho-metadata-editor