### PR TITLE
PDI-15515 - Removing legacy ESAPI encoder from projects

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -221,8 +221,7 @@
             <include name="jersey-json*.jar"/>
             <include name="jersey-bundle*.jar"/>
 
-            <!-- ESAPI version conflict with 2.0.1-->
-            <include name="ESAPI-2.0_rc6.jar"/>
+            <include name="encoder-1.2.jar"/>
 
             <include name="jackson*.jar"/>
 			<!-- Webservices -->

--- a/ivy.xml
+++ b/ivy.xml
@@ -123,7 +123,7 @@
 
     <dependency org="org.json" name="json" rev="${dependency.json.revision}" changing="true" conf="default->default"/>
     <!-- Miscellaneous BISERVER CE dependencies -->
-    <dependency org="org.owasp.esapi" name="esapi" rev="2.0.1" transitive="false" />
+    <dependency org="org.owasp.encoder" name="encoder"  rev="1.2"    transitive="false"/>
     <!-- test dependencies -->
     <dependency org="junit" name="junit" rev="4.4" conf="test->default"/>
     <!--<dependency org="pentaho" name="pentaho-bi-platform-test-foundation" rev="${dependency.bi-platform.revision}" conf="test->default" changing="true"/>-->


### PR DESCRIPTION
Removing legacy ESAPI encoder from projects and replacing it by org.owasp.encoder